### PR TITLE
bump Zed to v0.33.0

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Flags struct {
-	Topic       string
-	Namespace   string
-	ZedLakeHost string
+	Lake      string
+	Topic     string
+	Namespace string
 }
 
 type Credentials struct {
@@ -20,20 +20,14 @@ type Credentials struct {
 	Password string
 }
 
-const HostEnv = "ZED_LAKE_HOST"
-
-func DefaultHost() string {
-	host := os.Getenv(HostEnv)
-	if host == "" {
-		host = "localhost:9867"
-	}
-	return host
-}
-
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
+	lake := os.Getenv("ZED_LAKE")
+	if lake == "" {
+		lake = "http://localhost:9867"
+	}
+	fs.StringVar(&f.Lake, "lake", lake, "Zed lake service URL")
 	fs.StringVar(&f.Topic, "topic", "", "Kafka topic name")
 	fs.StringVar(&f.Namespace, "namespace", "io.brimdata.zync", "Kafka name space for new schemas")
-	fs.StringVar(&f.ZedLakeHost, "host", DefaultHost(), "host[:port] of Zed lake service")
 }
 
 func SchemaRegistryEndpoint() (string, Credentials, error) {

--- a/cmd/zync/etl/command.go
+++ b/cmd/zync/etl/command.go
@@ -62,7 +62,7 @@ func (c *Command) Run(args []string) error {
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT)
 	defer cancel()
-	lake, err := lakeapi.OpenRemoteLake(ctx, c.flags.ZedLakeHost)
+	lake, err := lakeapi.OpenRemoteLake(ctx, c.flags.Lake)
 	if err != nil {
 		return err
 	}

--- a/cmd/zync/from-kafka/command.go
+++ b/cmd/zync/from-kafka/command.go
@@ -63,7 +63,7 @@ func (f *From) Run(args []string) error {
 		return err
 	}
 	ctx := context.Background()
-	service, err := lakeapi.OpenRemoteLake(ctx, f.flags.ZedLakeHost)
+	service, err := lakeapi.OpenRemoteLake(ctx, f.flags.Lake)
 	if err != nil {
 		return err
 	}

--- a/cmd/zync/to-kafka/command.go
+++ b/cmd/zync/to-kafka/command.go
@@ -62,7 +62,7 @@ func (t *To) Run(args []string) error {
 		return err
 	}
 	ctx := context.Background()
-	service, err := lakeapi.OpenRemoteLake(ctx, t.flags.ZedLakeHost)
+	service, err := lakeapi.OpenRemoteLake(ctx, t.flags.Lake)
 	if err != nil {
 		return err
 	}

--- a/etl/pool.go
+++ b/etl/pool.go
@@ -144,7 +144,7 @@ func RunLocalJoin(zctx *zed.Context, left, right zio.Reader, query string) (zbuf
 	readers := []zio.Reader{left, right}
 	d := &batchDriver{}
 	dummy := &adaptor{}
-	_, err = driver.RunJoinWithFileSystem(context.TODO(), d, program, zctx, readers, dummy)
+	_, err = driver.RunWithFileSystem(context.TODO(), d, program, zctx, readers, dummy)
 	return d.Array, err
 }
 
@@ -159,9 +159,7 @@ func (b *batchDriver) Write(cid int, batch zbuf.Batch) error {
 	}
 	vals := batch.Values()
 	for i := range vals {
-		rec := &vals[i]
-		rec.Keep() //XXX
-		b.Append(rec)
+		b.Append(vals[i].Copy())
 	}
 	batch.Unref()
 	return nil

--- a/fifo/lake.go
+++ b/fifo/lake.go
@@ -139,8 +139,7 @@ func (b *batchDriver) Write(cid int, batch zbuf.Batch) error {
 	}
 	vals := batch.Values()
 	for i := range vals {
-		vals[i].Keep() //XXX
-		b.Append(&vals[i])
+		b.Append(vals[i].Copy())
 	}
 	batch.Unref()
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/brimdata/zync
 go 1.16
 
 require (
-	github.com/brimdata/zed v0.32.1-0.20211104130011-5d7469919ad8
+	github.com/brimdata/zed v0.33.0
 	github.com/confluentinc/confluent-kafka-go v1.7.0 // indirect
 	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11
 	github.com/riferrei/srclient v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stg
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brimdata/zed v0.32.1-0.20211104130011-5d7469919ad8 h1:X1CLF3bfx8aKfAQGO3mmrDSbUFNWtRnwZDHtcgsdebc=
-github.com/brimdata/zed v0.32.1-0.20211104130011-5d7469919ad8/go.mod h1:l+EPQAgv4gezHWXHMeX0dSI2ZrAOY9kcEaTeTVPEobg=
+github.com/brimdata/zed v0.33.0 h1:ErIVDyd/3fvKFsMbRsW7hnCVE/4OpgmAvHah4UuM6C4=
+github.com/brimdata/zed v0.33.0/go.mod h1:5B9cBgz1eitkYh6iW7aTJoJTLnOfgHcfGePF0+1F4N0=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/confluentinc/confluent-kafka-go v1.7.0 h1:tXh3LWb2Ne0WiU3ng4h5qiGA9XV61rz46w60O+cq8bM=
@@ -122,6 +122,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/pierrec/lz4/v4 v4.1.0 h1:vhiKjm9Npt49Up5EbHg5C/gjum3rWjmcjGnOK+wDeok=
 github.com/pierrec/lz4/v4 v4.1.0/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -231,8 +232,8 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=
-golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 h1:X/2sJAybVknnUnV7AD2HdT6rm2p5BP6eH2j+igduWgk=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 h1:EC6+IGYTjPpRfv9a2b/6Puw0W+hLtAhkV1tPsXhutqs=
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
Following Zed's lead, rename the ZED_LAKE_HOST environment variable to
ZED_LAKE and the -host flag to -lake.