### PR TITLE
use kafka.OffsetBeginning where appropriate

### DIFF
--- a/cmd/zync/consume/command.go
+++ b/cmd/zync/consume/command.go
@@ -59,7 +59,8 @@ func New(parent charm.Command, fs *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	fs.StringVar(&c.timeout, "timeout", "", "timeout in ZSON duration syntax (5s, 1m30s, ...)")
 	fs.StringVar(&c.group, "group", "", "Kafka consumer group name")
-	fs.Int64Var(&c.offset, "offset", 0, "Kafka offset in topic to begin at")
+	fs.Int64Var(&c.offset, "offset", int64(kafka.OffsetBeginning),
+		"initial Kafka offset (-2 is oldest, -1 is newest)")
 	c.flags.SetFlags(fs)
 	c.outputFlags.SetFlags(fs)
 	return c, nil

--- a/etl/pool.go
+++ b/etl/pool.go
@@ -98,12 +98,12 @@ func (p *Pool) NextConsumerOffset(topic string) (kafka.Offset, error) {
 	query := fmt.Sprintf("kafka.topic=='%s' | head 1 | offset:=kafka.input_offset", topic)
 	batch, err := p.Query(query)
 	if err != nil {
-		return 0, err
+		return kafka.OffsetBeginning, err
 	}
 	vals := batch.Values()
 	n := len(vals)
 	if n == 0 {
-		return 0, nil
+		return kafka.OffsetBeginning, nil
 	}
 	if n != 1 {
 		// This should not happen.

--- a/fifo/lake.go
+++ b/fifo/lake.go
@@ -88,12 +88,12 @@ func (l *Lake) NextConsumerOffset(topic string) (kafka.Offset, error) {
 	query := fmt.Sprintf("kafka.topic=='%s' | head 1 | offset:=kafka.input_offset", topic)
 	batch, err := l.Query(query)
 	if err != nil {
-		return 0, err
+		return kafka.OffsetBeginning, err
 	}
 	vals := batch.Values()
 	n := len(vals)
 	if n == 0 {
-		return 0, nil
+		return kafka.OffsetBeginning, nil
 	}
 	if n != 1 {
 		// This should not happen.


### PR DESCRIPTION
Zero isn't a good default offset for a Kafka consumer because it won't
see any messages if the topic's earliest offset is nonzero.  Use
kafka.OffsetBeginning instead.