### PR TITLE
filter by kafka.topic in to-kafka

### DIFF
--- a/fifo/lake.go
+++ b/fifo/lake.go
@@ -106,8 +106,8 @@ func (l *Lake) NextConsumerOffset(topic string) (kafka.Offset, error) {
 	return kafka.Offset(offset + 1), nil
 }
 
-func (l *Lake) ReadBatch(ctx context.Context, offset kafka.Offset, size int) (zbuf.Batch, error) {
-	query := fmt.Sprintf("kafka.offset >= %d | head %d", offset, size)
+func (l *Lake) ReadBatch(ctx context.Context, topic string, offset kafka.Offset, size int) (zbuf.Batch, error) {
+	query := fmt.Sprintf("kafka.topic=='%s' kafka.offset >= %d | head %d", topic, offset, size)
 	if l.shaper != "" {
 		query = fmt.Sprintf("%s | %s  | sort kafka.offset", query, l.shaper)
 	} else {

--- a/fifo/to.go
+++ b/fifo/to.go
@@ -36,7 +36,7 @@ func (t *To) Sync(ctx context.Context) error {
 	}
 	for {
 		// Query of batch of records that start at the given offset.
-		batch, err := t.src.ReadBatch(ctx, offset, BatchSize)
+		batch, err := t.src.ReadBatch(ctx, t.dst.topic, offset, BatchSize)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The command "zync to-kafka -topic T -pool P" synchronizes all records in
pool P to topic T regardless of kafka.topic, but this isn't the behavior
we want.  Restrict synchronization to records for which kafka.topic
matches T.