### PR TITLE
maintain kafka.offset per topic in from-kafka

### DIFF
--- a/fifo/from.go
+++ b/fifo/from.go
@@ -37,7 +37,7 @@ const BatchThresh = 10 * 1024 * 1024
 const BatchTimeout = 5 * time.Second
 
 func (f *From) Sync(ctx context.Context) (int64, int64, error) {
-	offset, err := f.dst.NextProducerOffset()
+	offset, err := f.dst.NextProducerOffset(f.src.topic)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/fifo/lake.go
+++ b/fifo/lake.go
@@ -59,10 +59,11 @@ func (l *Lake) LoadBatch(batch zbuf.Array) (ksuid.KSUID, error) {
 	return l.service.Load(context.TODO(), l.poolID, "main", &batch, api.CommitMessage{})
 }
 
-func (l *Lake) NextProducerOffset() (kafka.Offset, error) {
+func (l *Lake) NextProducerOffset(topic string) (kafka.Offset, error) {
 	// Run a query against the pool to get the max output offset.
 	// We assume the pool key is kafka.offset:asc so we just do "tail 1".
-	batch, err := l.Query("tail 1 | offset:=kafka.offset")
+	query := fmt.Sprintf("kafka.topic=='%s' | tail 1 | offset:=kafka.offset", topic)
+	batch, err := l.Query(query)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The "zync from-kafka" command adjusts kafka.offset in each record so it
is serialized (and thus unique) accross the entire destination pool, but
this isn't quite the behavior we want.  Serialize it separately for each
kafka.topic in the destination pool instead.