### PR TITLE
encode repeated record as reference in zavro.EncodeSchema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11
 	github.com/riferrei/srclient v0.4.0
 	github.com/segmentio/ksuid v1.0.2
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.16.0
 	gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183 // indirect
 	gopkg.in/confluentinc/confluent-kafka-go.v1 v1.7.0

--- a/zavro/schema_test.go
+++ b/zavro/schema_test.go
@@ -1,0 +1,49 @@
+package zavro
+
+import (
+	"testing"
+
+	"github.com/brimdata/zed"
+	"github.com/brimdata/zed/zson"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeSchemaRepeatedRecordBecomesReference(t *testing.T) {
+	typ, err := zson.ParseType(zed.NewContext(), "{a:{},b:{}}")
+	require.NoError(t, err)
+	schema, err := EncodeSchema(typ, "namespace")
+	require.NoError(t, err)
+	const expected = `
+{
+    "type": "record",
+    "namespace": "namespace",
+    "name": "zng_2d7e63a29282715120ae93531a98c9ef",
+    "doc": "Created by zync from zng type {a:{},b:{}}",
+    "fields": [
+        {
+            "name": "a",
+            "default": null,
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "namespace": "namespace",
+                    "name": "zng_99914b932bd37a50b983c5e7c90ae93b",
+                    "doc": "Created by zync from zng type {}",
+                    "fields": null
+                }
+            ]
+        },
+        {
+            "name": "b",
+            "default": null,
+            "type": [
+                "null",
+                "zng_99914b932bd37a50b983c5e7c90ae93b"
+            ]
+        }
+    ]
+}`
+	assert.JSONEq(t, expected, schema.String())
+}


### PR DESCRIPTION
For a Zed type containing two identical records (e.g, {a:{},b:{}})
zavro.EncodeSchema returns a schema containing two records with the same
name, which is something schema registries don't allow.  Change
EncodeSchema to use avro.RecursiveSchema for any Zed record type
previously encountered so that subsequent appearances of a record type
become references (rather than duplicates) in the returned schema.