### PR TITLE
encode null field as "null" in zavro.EncodeSchema

### DIFF
--- a/zavro/schema.go
+++ b/zavro/schema.go
@@ -40,11 +40,16 @@ func (s *schemaEncoder) encodeRecord(typ *zed.TypeRecord) (avro.Schema, error) {
 		if err != nil {
 			return nil, err
 		}
+		if _, ok := schema.(*avro.NullSchema); !ok {
+			// Avro unions may not contain more than one unnamed
+			// schema with the same type.
+			schema = &avro.UnionSchema{
+				Types: []avro.Schema{&avro.NullSchema{}, schema},
+			}
+		}
 		fld := &avro.SchemaField{
 			Name: col.Name,
-			Type: &avro.UnionSchema{
-				Types: []avro.Schema{&avro.NullSchema{}, schema},
-			},
+			Type: schema,
 		}
 		fields = append(fields, fld)
 	}

--- a/zavro/schema_test.go
+++ b/zavro/schema_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEncodeSchemaNullTypeRecordFielBecomeNullNotUnion(t *testing.T) {
+	typ, err := zson.ParseType(zed.NewContext(), "{a:null}")
+	require.NoError(t, err)
+	schema, err := EncodeSchema(typ, "namespace")
+	require.NoError(t, err)
+	const expected = `
+{
+    "type": "record",
+    "namespace": "namespace",
+    "name": "zng_4f5c13d8a692b16d2a7d297f951880a3",
+    "doc": "Created by zync from zng type {a:null}",
+    "fields": [
+        {
+            "name": "a",
+            "default": null,
+            "type": "null"
+        }
+    ]
+}`
+	assert.JSONEq(t, expected, schema.String(), schema.String())
+}
+
 func TestEncodeSchemaRepeatedRecordBecomesReference(t *testing.T) {
 	typ, err := zson.ParseType(zed.NewContext(), "{a:{},b:{}}")
 	require.NoError(t, err)


### PR DESCRIPTION
zavro.EncodeSchema encodes a Zed record field with the null type as an
Avro union containing "null" twice (i.e., as ["null","null"]), but Avro
unions may not contain more than one unnamed schema of the same type.
Fix this by encoding such field as "null" rather than as a union.