### PR TITLE
adjust ETL for JDBC sync connector records

### DIFF
--- a/demo/batch-1.zson
+++ b/demo/batch-1.zson
@@ -17,6 +17,9 @@
     topic: "Invoices",
     offset: 1
   },
+  key: {
+    ID: 100
+  },
   value: {
     op:"r",
     after:{
@@ -30,6 +33,9 @@
   kafka: {
     topic: "Invoices",
     offset: 2
+  },
+  key: {
+    ID: 101
   },
   value: {
     op:"r",
@@ -45,6 +51,9 @@
     topic: "InvoiceStatus",
     offset: 1
   },
+  key: {
+    ID: 80
+  },
   value: {
     op:"r",
     after:{
@@ -58,6 +67,9 @@
   kafka: {
     topic: "InvoiceStatus",
     offset: 2
+  },
+  key: {
+    ID: 32
   },
   value: {
     op:"r",

--- a/demo/batch-2.zson
+++ b/demo/batch-2.zson
@@ -3,6 +3,9 @@
     topic: "Invoices",
     offset: 3
   },
+  key: {
+   ID: 102
+  },
   value: {
     op:"c",
     after:{
@@ -17,6 +20,9 @@
     topic: "Invoices",
     offset: 4
   },
+  key: {
+   ID: 103
+  },
   value: {
     op:"c",
     after:{
@@ -30,6 +36,9 @@
   kafka: {
     topic: "InvoiceStatus",
     offset: 3
+  },
+  key: {
+   ID: 77
   },
   value: {
     op:"c",

--- a/demo/batch-3.zson
+++ b/demo/batch-3.zson
@@ -3,6 +3,9 @@
     topic: "InvoiceStatus",
     offset: 4
   },
+  key: {
+   ID: 192
+  },
   value: {
     op:"c",
     after:{
@@ -16,6 +19,9 @@
   kafka: {
     topic: "InvoiceStatus",
     offset: 5
+  },
+  key: {
+   ID: 32
   },
   value: {
     op:"u",

--- a/demo/batch-4.zson
+++ b/demo/batch-4.zson
@@ -3,6 +3,9 @@
     topic: "InvoiceStatus",
     offset: 6
   },
+  key: {
+   ID: 192
+  },
   value: {
     op:"u",
     after:{
@@ -17,6 +20,9 @@
     topic: "InvoiceStatus",
     offset: 7
   },
+  key: {
+   ID: 77
+  },
   value: {
     op:"u",
     after:{
@@ -30,6 +36,9 @@
   kafka: {
     topic: "InvoiceStatus",
     offset: 8
+  },
+  key: {
+   ID: 80
   },
   value: {
     op:"u",

--- a/demo/invoices.yaml
+++ b/demo/invoices.yaml
@@ -13,35 +13,49 @@ transforms:
     where: value.op in ["c", "r"]
     left: Invoices
     right: InvoiceStatus
-    join-on: Invoices.ID=InvoiceStatus.InvoiceID
+    join-on: left.value.after.ID=right.value.after.InvoiceID
     out: NewInvoices
     zed: |
-      | NewInvoices:={
-          ID: Invoices.ID,
-          customer: Invoices.customer,
-          item: Invoices.item,
-          invoice_status: InvoiceStatus.status
+      | out:={
+          key: left.key,
+          value: {
+            ID: left.value.after.ID,
+            customer: left.value.after.customer,
+            item: left.value.after.item,
+            invoice_status: right.value.after.status
+          }
         }
   - type: stateless
     where: value.op=="u"
     in: InvoiceStatus
     out: NewInvoices
     zed: |
-      | NewInvoices:={
-          ID: InvoiceStatus.InvoiceID,
-          invoice_status: InvoiceStatus.status
+      | out:={
+          key: {
+            ID: in.value.after.InvoiceID
+          },
+          value: {
+            ID: in.value.after.InvoiceID,
+            invoice_status: in.value.after.status
+          }
         }
   - type: stateless
     where: value.op=="u"
     in: Invoices
     out: NewInvoices
     zed: |
-      | NewInvoices:=Invoices
+      | out:={
+          key: in.key,
+          value: in.value.after
+        }
   # We could get an update on InvoiceStatus after this delete and presumably
   # that would cause on update error, but maybe that's ok?
   - type: stateless
-    where: value.op=="d"
+    where: value.op=="d" value.op=="Disabled until casting null to record is fixed"
     in: Invoices
     out: NewInvoices
     zed: |
-      | NewInvoices.ID:=Invoices.ID
+      | out:={
+          key: in.key,
+          value: cast(null, typeof(in.value.before))
+        }


### PR DESCRIPTION
ETL transforms need access to Debezium event keys to produce valid JDBC
sync connector records.  Give them access to the entire event as
this.left and this.right for denorm transforms and as this.in for
stateless transforms, and change the output field to this.out for
consistency.