### PR TITLE
allow non-HTTP lakes

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Flags struct {
-	Lake      string
 	Topic     string
 	Namespace string
 }
@@ -21,11 +20,6 @@ type Credentials struct {
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
-	lake := os.Getenv("ZED_LAKE")
-	if lake == "" {
-		lake = "http://localhost:9867"
-	}
-	fs.StringVar(&f.Lake, "lake", lake, "Zed lake service URL")
 	fs.StringVar(&f.Topic, "topic", "", "Kafka topic name")
 	fs.StringVar(&f.Namespace, "namespace", "io.brimdata.zync", "Kafka name space for new schemas")
 }

--- a/cli/lake.go
+++ b/cli/lake.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"flag"
+
+	zedcli "github.com/brimdata/zed/cli"
+)
+
+type LakeFlags struct {
+	zedcli.LakeFlags
+}
+
+// SetFlags calls LakeFlags.LakeFlags.SetFlags and then, for any flag added, it
+// prepends "Zed " to flag.Flag.Usage.
+func (l *LakeFlags) SetFlags(fs *flag.FlagSet) {
+	beforeSetFlags := map[string]struct{}{}
+	fs.VisitAll(func(f *flag.Flag) {
+		beforeSetFlags[f.Name] = struct{}{}
+	})
+	l.LakeFlags.SetFlags(fs)
+	fs.VisitAll(func(f *flag.Flag) {
+		if _, ok := beforeSetFlags[f.Name]; !ok {
+			f.Usage = "Zed " + f.Usage
+		}
+	})
+
+}

--- a/cmd/zync/etl/command.go
+++ b/cmd/zync/etl/command.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"syscall"
 
-	lakeapi "github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zync/cli"
 	"github.com/brimdata/zync/cmd/zync/root"
@@ -38,14 +37,16 @@ func init() {
 
 type Command struct {
 	*root.Command
-	zed   bool
-	flags cli.Flags
+	zed       bool
+	flags     cli.Flags
+	lakeFlags cli.LakeFlags
 }
 
 func New(parent charm.Command, fs *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	fs.BoolVar(&c.zed, "zed", false, "dump compiled Zed to stdout and exit)")
 	c.flags.SetFlags(fs)
+	c.lakeFlags.SetFlags(fs)
 	return c, nil
 }
 
@@ -62,7 +63,7 @@ func (c *Command) Run(args []string) error {
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT)
 	defer cancel()
-	lake, err := lakeapi.OpenRemoteLake(ctx, c.flags.Lake)
+	lake, err := c.lakeFlags.Open(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/zync/from-kafka/command.go
+++ b/cmd/zync/from-kafka/command.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/brimdata/zed"
-	lakeapi "github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zync/cli"
 	"github.com/brimdata/zync/cmd/zync/root"
@@ -39,10 +38,11 @@ of how this works.
 
 type From struct {
 	*root.Command
-	flags  cli.Flags
-	shaper cli.ShaperFlags
-	group  string
-	pool   string
+	flags     cli.Flags
+	lakeFlags cli.LakeFlags
+	shaper    cli.ShaperFlags
+	group     string
+	pool      string
 }
 
 func NewFrom(parent charm.Command, fs *flag.FlagSet) (charm.Command, error) {
@@ -50,6 +50,7 @@ func NewFrom(parent charm.Command, fs *flag.FlagSet) (charm.Command, error) {
 	fs.StringVar(&f.group, "group", "", "Kafka consumer group name")
 	fs.StringVar(&f.pool, "pool", "", "name of Zed data pool")
 	f.flags.SetFlags(fs)
+	f.lakeFlags.SetFlags(fs)
 	f.shaper.SetFlags(fs)
 	return f, nil
 }
@@ -67,7 +68,7 @@ func (f *From) Run(args []string) error {
 		return err
 	}
 	ctx := context.Background()
-	service, err := lakeapi.OpenRemoteLake(ctx, f.flags.Lake)
+	service, err := f.lakeFlags.Open(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/zync/to-kafka/command.go
+++ b/cmd/zync/to-kafka/command.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 
 	"github.com/brimdata/zed"
-	lakeapi "github.com/brimdata/zed/lake/api"
 	"github.com/brimdata/zed/pkg/charm"
 	"github.com/brimdata/zync/cli"
 	"github.com/brimdata/zync/cmd/zync/root"
@@ -40,15 +39,17 @@ according to the kafka.offset value in the data pool.
 
 type To struct {
 	*root.Command
-	flags  cli.Flags
-	shaper cli.ShaperFlags
-	pool   string
+	flags     cli.Flags
+	lakeFlags cli.LakeFlags
+	shaper    cli.ShaperFlags
+	pool      string
 }
 
 func NewTo(parent charm.Command, fs *flag.FlagSet) (charm.Command, error) {
 	f := &To{Command: parent.(*root.Command)}
 	fs.StringVar(&f.pool, "pool", "", "name of Zed data pool")
 	f.flags.SetFlags(fs)
+	f.lakeFlags.SetFlags(fs)
 	f.shaper.SetFlags(fs)
 	return f, nil
 }
@@ -66,7 +67,7 @@ func (t *To) Run(args []string) error {
 		return err
 	}
 	ctx := context.Background()
-	service, err := lakeapi.OpenRemoteLake(ctx, t.flags.Lake)
+	service, err := t.lakeFlags.Open(ctx)
 	if err != nil {
 		return err
 	}

--- a/fifo/lake.go
+++ b/fifo/lake.go
@@ -21,13 +21,13 @@ import (
 var ErrBadPoolKey = errors.New("pool key must be 'kafka.offset' in ascending order")
 
 type Lake struct {
-	service *lakeapi.RemoteSession
+	service lakeapi.Interface
 	shaper  string
 	pool    string
 	poolID  ksuid.KSUID
 }
 
-func NewLake(ctx context.Context, poolName, shaper string, server *lakeapi.RemoteSession) (*Lake, error) {
+func NewLake(ctx context.Context, poolName, shaper string, server lakeapi.Interface) (*Lake, error) {
 	pool, err := lakeapi.LookupPoolByName(ctx, server, poolName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replace github.com/brimdata/zed/lake/api.OpenRemoteLake with
github.com/brimdata/zed/cli.LakeFlags.Open to allow access to non-HTTP
lakes.