### PR TITLE
adjust JSON field order for Apicurio in zavro.EncodeSchema

### DIFF
--- a/zavro/schema_test.go
+++ b/zavro/schema_test.go
@@ -9,6 +9,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEncodeSchemaJSONFieldOrderMatchesJava(t *testing.T) {
+	typ, err := zson.ParseType(zed.NewContext(), "{a:{b:{}}}")
+	require.NoError(t, err)
+	schema, err := EncodeSchema(typ, "namespace")
+	require.NoError(t, err)
+	const expected = `{
+    "type": "record",
+    "name": "zng_228c5f7a92fa77715f4dabe46739bfa3",
+    "namespace": "namespace",
+    "doc": "Created by zync from zng type {a:{b:{}}}",
+    "fields": [
+        {
+            "name": "a",
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "name": "zng_eeb636be88d6a4d3387b3820995db8e7",
+                    "namespace": "namespace",
+                    "doc": "Created by zync from zng type {b:{}}",
+                    "fields": [
+                        {
+                            "name": "b",
+                            "type": [
+                                "null",
+                                {
+                                    "type": "record",
+                                    "name": "zng_99914b932bd37a50b983c5e7c90ae93b",
+                                    "namespace": "namespace",
+                                    "doc": "Created by zync from zng type {}",
+                                    "fields": null
+                                }
+                            ],
+                            "default": null
+                        }
+                    ]
+                }
+            ],
+            "default": null
+        }
+    ]
+}`
+	// Equal instead of JSONEq because JSON field order matters for this test.
+	assert.Equal(t, expected, schema.String(), schema.String())
+}
+
 func TestEncodeSchemaNullTypeRecordFielBecomeNullNotUnion(t *testing.T) {
 	typ, err := zson.ParseType(zed.NewContext(), "{a:null}")
 	require.NoError(t, err)


### PR DESCRIPTION
For a given Avro schema, JSON produced from Go by
github.com/go-avro/avro.Schema.MarshalJSON or String and from Java by
org.apache.avro.Schema.toString differs sufficiently that Apicurio
Registry's implementation of POST /subjects/{schema} does not consider
them to be the same schema.  Fix by wrapping each avro.RecordSchmea
returned by zavro.EncodeSchema with a zavro.compatReccordSchema whose
MarshalJSON and String methods emit JSON fields in the Java order.