### PR TITLE
connectjson: handle empty envelope

### DIFF
--- a/connectjson/connectjson.go
+++ b/connectjson/connectjson.go
@@ -4,6 +4,7 @@
 package connectjson
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -30,6 +31,9 @@ type connectSchema struct {
 }
 
 func Encode(val *zed.Value) ([]byte, error) {
+	if zed.TypeUnder(val.Type) == zed.TypeNull {
+		return nil, nil
+	}
 	schema, err := marshalSchema(val.Type)
 	if err != nil {
 		return nil, err
@@ -178,6 +182,10 @@ func NewDecoder(zctx *zed.Context) *Decoder {
 }
 
 func (c *Decoder) Decode(b []byte) (*zed.Value, error) {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 {
+		return zed.Null, nil
+	}
 	var v connectEnvelope
 	if err := json.Unmarshal(b, &v); err != nil {
 		return nil, err

--- a/connectjson/connectjson_test.go
+++ b/connectjson/connectjson_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestConnectJSON(t *testing.T) {
 	var cases = []string{
+		`null`,
 		`true`,
 		`8(int8)`,
 		`16(int16)`,
@@ -41,5 +42,13 @@ func TestConnectJSON(t *testing.T) {
 		actual, err := NewDecoder(zctx).Decode(b)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual, s)
+	}
+}
+
+func TestConnectJSONDecodeEmptyEnvelope(t *testing.T) {
+	for _, b := range [][]byte{nil, {}, []byte(" \n")} {
+		val, err := NewDecoder(zed.NewContext()).Decode(b)
+		require.NoError(t, err, b)
+		assert.Equal(t, zed.Null, val, b)
 	}
 }


### PR DESCRIPTION
Decode an empty Connect JSON envelope as a Zed value with type null, and
encode a Zed value with type null as an empty envelope.  (Debezium
tombstone events have a non-empty key and an empty value.)