### PR TITLE
connectjson: further improve decode performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/brimdata/zed v1.1.1-0.20220712185418-e0683b108af4
+	github.com/buger/jsonparser v1.1.1
 	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11
 	github.com/riferrei/srclient v0.4.0
 	github.com/segmentio/ksuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f h1:y06x6vGnFYf
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/brimdata/zed v1.1.1-0.20220712185418-e0683b108af4 h1:pFvcUP+QjC8z49+8SctZ3VxBvo5N04hilZ6MElOH3Hs=
 github.com/brimdata/zed v1.1.1-0.20220712185418-e0683b108af4/go.mod h1:HAAkiXG5honjnAPkVow2FtZW9w6Jbz60nyj22I3n+fA=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=


### PR DESCRIPTION
Decoder.Decode always calls json.Unmarshal and Decoder.decodeSchema, both of which are expensive.  Speed things up by calling them only if the Decoder hasn't seen the schema's JSON encoding before.