### PR TITLE
Upgrade to actions/checkout@v3 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: make fmt
       - run: make tidy
       - run: make vet


### PR DESCRIPTION
v2 is deprecated because it uses Node.js 12, which is no longer supported.

(inspired by https://github.com/brimdata/zed/pull/4185)