### PR TITLE
reduce "zync from-kafka" concurrency and memory usage

### DIFF
--- a/cmd/zync/consume/command.go
+++ b/cmd/zync/consume/command.go
@@ -86,7 +86,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	zctx := zed.NewContext()
-	consumer, err := fifo.NewConsumer(zctx, config, registry, c.flags.Format, c.flags.Topic, c.offset, false)
+	consumer, err := fifo.NewConsumer(zctx, config, registry, c.flags.Format, map[string]int64{c.flags.Topic: c.offset}, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/zync/info/command.go
+++ b/cmd/zync/info/command.go
@@ -51,11 +51,11 @@ func (c *Command) Run(args []string) error {
 	registry := srclient.CreateSchemaRegistryClient(url)
 	registry.SetCredentials(secret.User, secret.Password)
 	zctx := zed.NewContext()
-	consumer, err := fifo.NewConsumer(zctx, config, registry, c.flags.Format, c.flags.Topic, 0, false)
+	consumer, err := fifo.NewConsumer(zctx, config, registry, c.flags.Format, nil, false)
 	if err != nil {
 		return err
 	}
-	low, high, err := consumer.Watermarks(context.Background())
+	low, high, err := consumer.Watermarks(context.Background(), c.flags.Topic)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/twmb/franz-go v1.9.1
 	github.com/twmb/franz-go/pkg/kadm v0.0.0-20220331035613-01d0c45d69d2
+	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -37,7 +38,6 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0 // indirect
-	golang.org/x/exp v0.0.0-20220916125017-b168a2c6b86b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
"zync from-kafka" creates a goroutine and Kafka client per Kafka topic, leading to substantial CPU and memory usage when the number of topics is large.  Reduce both by creating a single goroutine and Kafka client for all topics.