### PR TITLE
add -kafka.replicas flag to "zync from-kafka"

### DIFF
--- a/fifo/admin.go
+++ b/fifo/admin.go
@@ -1,0 +1,31 @@
+package fifo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// CreateMissingTopics creates topics, ignoring any that already exist.
+func CreateMissingTopics(ctx context.Context, opts []kgo.Opt, partitions int32, replicationFactor int16, configs map[string]*string, topics ...string) error {
+	client, err := kadm.NewOptClient(opts...)
+	if err != nil {
+		return err
+	}
+	// Create topics one by one to avoid a timeout due to a slow broker.
+	for _, topic := range topics {
+		resps, err := client.CreateTopics(ctx, partitions, replicationFactor, configs, topic)
+		if err != nil {
+			return err
+		}
+		for _, r := range resps {
+			if r.Err != nil && r.Err != kerr.TopicAlreadyExists {
+				return fmt.Errorf("creating topic %s: %w", r.Topic, r.Err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
When the -kafka.replicas flag is set to a positive integer, "zync from-kafka" interprets it as a replication factor and attempts to create each topic from which it will consume with one partition and the given replication factor.  Existing topics are ignored, including those with a different number of partitions or replication factor.

Creating missing topics can reduce CPU utilization in zync and the Kafka broker caused by the Kafka client package, which otherwise repeatedly updates topic metadata to poll for creation of those topics.