### PR TITLE
.github/workflows: upgrade to actions/setup-go@v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
       - run: make fmt
       - run: make tidy
       - run: make vet


### PR DESCRIPTION
This version lets us pull the Go version from go.mod, so do that.