### PR TITLE
Allow org.apache names in Connect JSON schema

### DIFF
--- a/connectjson/connectjson.go
+++ b/connectjson/connectjson.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/brimdata/zed"
 	"github.com/brimdata/zed/runtime/sam/expr"
@@ -229,9 +228,6 @@ func (c *Decoder) Decode(b []byte) (zed.Value, error) {
 }
 
 func (c *Decoder) decodeSchema(s *connectSchema) (string, zed.Type, error) {
-	if strings.HasPrefix(s.Name, "org.apache") {
-		panic("XXX " + s.Name)
-	}
 	var typ zed.Type
 	var err error
 	switch s.Type {


### PR DESCRIPTION
connectjson.Decoder deliberately panics if it encounters a schema element whose name begins with org.apache.  Remove that behavior so org.apache names are allowed.

(The panic is left over from development of the connectjson package, when it wasn't clear whether to interpret values according to schema element names during decoding.  For example, a value whose corresponding schema element has type int64 and name
org.apache.kafka.connect.data.Timestamp could be interpreted either as a simple int64 or, per the name, as a time in milliseconds since the Unix epoch.  The connectjson package takes the former approach, mostly because the current decoding process offers no easy way to perform the necessary scaling.)