### PR TITLE
Upgrade Node 16 actions in .github/workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,8 @@ jobs:
         ports:
           - 9092:9092
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: make fmt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,10 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
     - run: make fmt
@@ -18,7 +18,7 @@ jobs:
     - run: make vet
     - run: make test-unit
     - run: make test-system
-    - uses: goreleaser/goreleaser-action@v3
+    - uses: goreleaser/goreleaser-action@v5
       with:
         args: release --clean
       env:


### PR DESCRIPTION
Node 16 actions are deprecated so upgrade to the Node 20 versions.

(Upgrade gorelease/goreleaser-action to v5 because v6 requires changes to .goreleaser.yaml.)